### PR TITLE
feat: skip authentication for recipe index and show

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -1,5 +1,6 @@
 class RecipesController < ApplicationController
   before_action :authenticate_user!
+  skip_before_action :authenticate_user!, only: [:index, :show]
   def index
     @q = Recipe.ransack(params[:q])
     @recipes = @q.result(distinct: true).includes(:user).order(created_at: :desc)


### PR DESCRIPTION
## 概要
ogp表示のためrecipeのアクションを認証不要に

## 変更点
 
skip_before_action :authenticate_user!, only: [:index, :show]　の記述

## 動作確認
ログインせずに該当のレシピのアクションが動作することを確認
