### PR TITLE
image url検証

### DIFF
--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -74,7 +74,7 @@ end
 
   def ogp_image_url(host:)
     if Rails.env.production?
-      image.url(width: 1200, height: 630, crop: :fill)
+      image.url
     else
       Rails.application.routes.url_helpers.rails_blob_url(image, host: host)
     end


### PR DESCRIPTION
## 概要
image urlのバグを検証

## 変更点
 ogp_image_urlメソッドの戻り値の画像を変換せずそのまま返す