### PR TITLE
variantメソッドの中身修正

### DIFF
--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -21,7 +21,6 @@ class Recipe < ApplicationRecord
 
     image.variant(
     resize_to_limit: [width, height],
-    saver: { quality: 80 },
     format: :webp
     )
   end


### PR DESCRIPTION
## 概要
画像加工メソッド変更により画像が表示されないバグを修正

## 変更点
variantの中身からsaverを削除(Minimagickで対応していない）

## 動作確認
開発環境で画像が表示されることを確認

