### PR TITLE
ドメイン名修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,7 +91,7 @@ config.action_mailer.smtp_settings = {
   authentication: "plain",
   enable_starttls_auto: true
 }
-config.action_mailer.default_url_options = { host: "https://my-muscle-meal.com" }
+config.action_mailer.default_url_options = { host: "my-muscle-meal.com" }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
## 概要
本番環境設定のドメイン名修正

## 変更点
production.rbのホスト名から"https:"部分を削除