### PR TITLE
ポート番号の変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -84,17 +84,21 @@ Rails.application.configure do
 config.action_mailer.delivery_method = :smtp
 config.action_mailer.smtp_settings = {
   address: "smtp.resend.com",
-  port: 587,
+  port: 465,
   domain: "my-muscle-meal.com",
   user_name: "resend",
   password: ENV["RESEND_API_KEY"],
   authentication: :plain,
-  enable_starttls_auto: true
+  ssl: true
 }
 
 config.action_mailer.default_url_options = {
   host: "my-muscle-meal.com",
   protocol: "https"
+}
+
+config.action_mailer.default_options = {
+  from: "no-reply@my-muscle-meal.com"
 }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to


### PR DESCRIPTION
## 概要
メール送信のポート番号変更

## 変更点
- config.action_mailer.smtp_settingsのポート番号を587から465に変更
- 送信元メールアドレスをno-reply@my-muscle-meal.comに設定