### PR TITLE
パスワードリセットURLの修正

### DIFF
--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -1,6 +1,6 @@
 class DeviseMailer < Devise::Mailer
   def reset_password_instructions(record, token, opts = {})
-    reset_url = edit_password_url(record, reset_password_token: token)
+    reset_url = edit_user_password_url(reset_password_token: token)
 
     Resend::Emails.send({
       from: "no-reply@my-muscle-meal.com",


### PR DESCRIPTION
## 概要
devise mailerのリセットURLの修正

## 変更点
devise mailerに reset_url = edit_user_password_url(reset_password_token: token)を追加修正
