### PR TITLE
カレンダーの献立名から詳細表示

### DIFF
--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -40,8 +40,13 @@
 
             <div class="max-h-20 overflow-y-auto space-y-1">
               <% events_for_day.each do |event| %>
-                <div class="text-xs bg-green-500/20 text-green-300 px-2 py-1 rounded truncate w-full">
-                  <%= event.menu&.name %>
+                <div class="text-xs bg-white text-black px-2 py-1 rounded truncate w-full">
+                  
+                  <% if event.menu.present? %>
+                    <%= link_to event.menu.name, menu_path(event.menu),
+                        class: "block hover:underline" %>
+                  <% end %>
+
                 </div>
               <% end %>
             </div>


### PR DESCRIPTION
## 概要
カレンダーの献立名から献立の詳細表示機能追加

## 変更点
- 献立名表示部分をlink_toに変更
- link_toの遷移先を献立の詳細画面に設定

## 動作確認
開発環境で画面遷移が行われることを確認