### PR TITLE
月間カレンダーと週間カレンダーを切り替えられるUI（タブ）

### DIFF
--- a/app/views/calendars/_view_toggle.html.erb
+++ b/app/views/calendars/_view_toggle.html.erb
@@ -1,0 +1,11 @@
+<div class="flex justify-center mb-4 gap-2">
+
+  <%= link_to "月間",
+      calendar_path(start_date: start_date),
+      class: "px-4 py-1 rounded bg-gray-800 #{'bg-blue-500 text-white' if current_view == :month}" %>
+
+  <%= link_to "週間",
+      calendar_week_path(start_date: start_date),
+      class: "px-4 py-1 rounded bg-gray-800 #{'bg-blue-500 text-white' if current_view == :week}" %>
+
+</div>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,3 +1,9 @@
+<div class="flex justify-center mb-2">
+  <%= render "view_toggle",
+      start_date: @start_date,
+      current_view: :month %>
+</div>
+
 <div class="flex items-center justify-center gap-6 mb-4 text-gray-300">
 
   <%= link_to "←", calendar_path(start_date: @start_date.prev_month),

--- a/app/views/simple_calendar/_week_calendar.html.erb
+++ b/app/views/simple_calendar/_week_calendar.html.erb
@@ -1,3 +1,9 @@
+<div class="flex justify-center mb-2">
+  <%= render "view_toggle",
+      start_date: @start_date,
+      current_view: :week %>
+</div>
+
 <div class="flex items-center justify-center gap-6 mb-4 text-gray-300">
 
   <%= link_to "←", calendar_week_path(start_date: @start_date.prev_week),


### PR DESCRIPTION
## 概要

月間カレンダーと週間カレンダーを切り替えられるUI（タブ）を実装

## 変更内容
- 切り替えUIの追加
- 月間 / 週間のタブUIを新規実装
- パーシャル化
- 切り替えUIを _view_toggle.html.erb としてパーシャル化
- 月間・週間どちらの画面からも再利用可能な構成に変更